### PR TITLE
Parse CD and CO parameters from CA

### DIFF
--- a/src/Mapper.php
+++ b/src/Mapper.php
@@ -54,6 +54,13 @@ final class Mapper implements IMapper
         );
 
         $AA = $VBAS->AA;
+
+        if (isset($AA->CA) && !isset($AA->CD) && !isset($AA->CO)) {
+            $ca = explode('/', strval($AA->CA));
+            $AA->CD = $ca[0];
+            $AA->CO = $ca[1];
+        }
+
         $address = new Entity\Address(
             intval($AA->IDA),
             intval($AA->KS),


### PR DESCRIPTION
Some result doesn't contain CD and CO parameters, but can be parsed from CA parameter. Example: 
```
<D:AA zdroj="ARES">
<D:IDA>210870551</D:IDA>
<D:KS>203</D:KS>
<D:NS>Česká republika</D:NS>
<D:N>Praha 6</D:N>
<D:NCO>Břevnov</D:NCO>
<D:NU>U třetí baterie</D:NU>
<D:CA>1056/5</D:CA>
<D:PSC>16200</D:PSC>
<D:AU> </D:AU>
</D:AA>
```